### PR TITLE
Reconcile APIs between HTTP and Socket

### DIFF
--- a/server/Order.js
+++ b/server/Order.js
@@ -125,7 +125,7 @@ Order.prototype = {
             socketUtil.broadcast('placementCreatedEvent', {
                 orderId: this.id,
                 quantityPlaced: quantityToPlace,
-                orderStatus: this.status
+                status: this.status
             });
         }
     },
@@ -194,7 +194,7 @@ Order.prototype = {
                 orderId: this.id,
                 quantityExecuted: quantityToExecute,
                 executionPrice: executionPrice,
-                orderStatus: this.status
+                status: this.status
             });
         }
     }


### PR DESCRIPTION
HTTP API and Socket API disagreed on field name status/orderStatus. Reconciled to 'status' in Socket API.
